### PR TITLE
Fix error loading project

### DIFF
--- a/src/common/localization/en.json
+++ b/src/common/localization/en.json
@@ -482,10 +482,6 @@
         "activeLearningPredictionError": {
             "title": "Active Learning Error",
             "message": "An error occurred while predicting regions in the current asset.                 Please verify your active learning configuration and try again"
-        },
-        "actionSendingError": {
-            "title": "Action Error",
-            "message": "An error occurred while trying to send an action.                 Please check the regions of the last image"
         }
     },
     "consoleMessages": {

--- a/src/common/localization/en.json
+++ b/src/common/localization/en.json
@@ -482,6 +482,10 @@
         "activeLearningPredictionError": {
             "title": "Active Learning Error",
             "message": "An error occurred while predicting regions in the current asset.                 Please verify your active learning configuration and try again"
+        },
+        "actionSendingError": {
+            "title": "Action Error",
+            "message": "An error occurred while trying to send an action.                 Please check the regions of the last image"
         }
     },
     "wasteTypes": {

--- a/src/common/localization/en.json
+++ b/src/common/localization/en.json
@@ -488,6 +488,12 @@
             "message": "An error occurred while trying to send an action.                 Please check the regions of the last image"
         }
     },
+    "consoleMessages": {
+        "getLitterFailed": "Failed to get the list of litters",
+        "imgOutFailed": "Failed to send img_out action",
+        "imgInFailed": "Failed to send img_in action",
+        "loadProjectFailed": "Could not load project"
+    },
     "wasteTypes": {
         "1": "Cigarette",
         "2": "Leaf",

--- a/src/common/localization/es.json
+++ b/src/common/localization/es.json
@@ -482,6 +482,10 @@
     "activeLearningPredictionError":{ 
       "title":"Error de aprendizaje",
       "message":"Se ha producido un error al predecir regiones en el activo actual.                 Compruebe la configuración de aprendizaje activa y vuelva a intentarlo"
+    },
+    "actionSendingError": {
+        "title": "Error de acción",
+        "message": "Se produjo un error al intentar enviar una acción.                Por favor verifique las regiones de la última imagen"
     }
   },
   "wasteTypes":{ 

--- a/src/common/localization/es.json
+++ b/src/common/localization/es.json
@@ -482,10 +482,6 @@
     "activeLearningPredictionError":{ 
       "title":"Error de aprendizaje",
       "message":"Se ha producido un error al predecir regiones en el activo actual.                 Compruebe la configuración de aprendizaje activa y vuelva a intentarlo"
-    },
-    "actionSendingError": {
-        "title": "Error de acción",
-        "message": "Se produjo un error al intentar enviar una acción.                Por favor verifique las regiones de la última imagen"
     }
   },
   "consoleMessages": {

--- a/src/common/localization/es.json
+++ b/src/common/localization/es.json
@@ -488,6 +488,12 @@
         "message": "Se produjo un error al intentar enviar una acción.                Por favor verifique las regiones de la última imagen"
     }
   },
+  "consoleMessages": {
+      "getLitterFailed": "No se pudo obtener la lista de camadas",
+      "imgOutFailed": "Error al enviar la acción img_out",
+      "imgInFailed": "Error al enviar la acción img_in",
+      "loadProjectFailed": "No se pudo cargar el proyecto"
+  },
   "wasteTypes":{ 
     "1":"Cigarrillo",
     "2":"Hoja",

--- a/src/common/strings.ts
+++ b/src/common/strings.ts
@@ -455,7 +455,6 @@ export interface IAppStrings {
         pasteRegionTooBigError: IErrorMetadata;
         exportFormatNotFound: IErrorMetadata;
         activeLearningPredictionError: IErrorMetadata;
-        actionSendingError: IErrorMetadata;
     };
     consoleMessages: {
         getLitterFailed: string;

--- a/src/common/strings.ts
+++ b/src/common/strings.ts
@@ -455,6 +455,7 @@ export interface IAppStrings {
         pasteRegionTooBigError: IErrorMetadata;
         exportFormatNotFound: IErrorMetadata;
         activeLearningPredictionError: IErrorMetadata;
+        actionSendingError: IErrorMetadata;
     };
     wasteTypes: {
         1: string;

--- a/src/common/strings.ts
+++ b/src/common/strings.ts
@@ -457,6 +457,12 @@ export interface IAppStrings {
         activeLearningPredictionError: IErrorMetadata;
         actionSendingError: IErrorMetadata;
     };
+    consoleMessages: {
+        getLitterFailed: string;
+        imgOutFailed: string;
+        imgInFailed: string;
+        loadProjectFailed: string;
+    };
     wasteTypes: {
         1: string;
         2: string;

--- a/src/models/applicationState.ts
+++ b/src/models/applicationState.ts
@@ -54,7 +54,6 @@ export enum ErrorCode {
     PasteRegionTooBig = "pasteRegionTooBig",
     OverloadedKeyBinding = "overloadedKeyBinding",
     ActiveLearningPredictionError = "activeLearningPredictionError",
-    ActionSendingError = "actionSendingError"
 }
 
 /**

--- a/src/models/applicationState.ts
+++ b/src/models/applicationState.ts
@@ -53,7 +53,7 @@ export enum ErrorCode {
     ExportFormatNotFound = "exportFormatNotFound",
     PasteRegionTooBig = "pasteRegionTooBig",
     OverloadedKeyBinding = "overloadedKeyBinding",
-    ActiveLearningPredictionError = "activeLearningPredictionError",
+    ActiveLearningPredictionError = "activeLearningPredictionError"
 }
 
 /**

--- a/src/models/applicationState.ts
+++ b/src/models/applicationState.ts
@@ -53,7 +53,8 @@ export enum ErrorCode {
     ExportFormatNotFound = "exportFormatNotFound",
     PasteRegionTooBig = "pasteRegionTooBig",
     OverloadedKeyBinding = "overloadedKeyBinding",
-    ActiveLearningPredictionError = "activeLearningPredictionError"
+    ActiveLearningPredictionError = "activeLearningPredictionError",
+    ActionSendingError = "actionSendingError"
 }
 
 /**

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -183,14 +183,13 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                     this.isAssetModified()
                 );
             };
-        } catch(e) {
+        } catch (e) {
             console.warn("Action img_out could not be sent.");
         }
-            const litters = await apiService.getLitters();
-            this.setState({
-                litters: litters.data
-            }); 
-       
+        const litters = await apiService.getLitters();
+        this.setState({
+            litters: litters.data
+        });
     }
 
     public saveImages = (images: IImageWithAction[]) => {
@@ -774,12 +773,12 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
          * Track user leaves the image
          */
         if (selectedAsset && selectedAsset.asset) {
-            try{
+            try {
                 const imgOut = await trackingActions.trackingImgOut(
-                auth.userId,
-                selectedAsset.asset.id,
-                selectedAsset.regions,
-                this.isAssetModified()
+                    auth.userId,
+                    selectedAsset.asset.id,
+                    selectedAsset.regions,
+                    this.isAssetModified()
                 );
 
                 const id = parseInt(selectedAsset.asset.id, 10);
@@ -795,11 +794,9 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                     images: changedImages
                 });
                 this.saveImages(changedImages);
-            } catch(e) {
+            } catch (e) {
                 console.warn("Action img_out could not be sent.");
-            };
-            
-            
+            }
         }
 
         const assetMetadata = await actions.loadAssetMetadata(project, asset);
@@ -828,10 +825,9 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
          */
         try {
             await trackingActions.trackingImgIn(auth.userId, assetMetadata.asset.id, assetMetadata.regions);
-        } catch(e) {
+        } catch (e) {
             console.warn("Action img_in could not be sent.");
         }
-        
     };
 
     private isAssetModified = (): boolean => {

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -184,7 +184,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                 );
             };
         } catch (e) {
-            console.warn("Action img_out could not be sent.");
+            console.warn(strings.consoleMessages.imgOutFailed);
         }
         const litters = await apiService.getLitters();
         this.setState({
@@ -795,7 +795,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                 });
                 this.saveImages(changedImages);
             } catch (e) {
-                console.warn("Action img_out could not be sent.");
+                console.warn(strings.consoleMessages.imgOutFailed);
             }
         }
 
@@ -826,7 +826,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
         try {
             await trackingActions.trackingImgIn(auth.userId, assetMetadata.asset.id, assetMetadata.regions);
         } catch (e) {
-            console.warn("Action img_in could not be sent.");
+            console.warn(strings.consoleMessages.imgInFailed);
         }
     };
 

--- a/src/redux/actions/projectActions.ts
+++ b/src/redux/actions/projectActions.ts
@@ -62,7 +62,6 @@ export function loadProject(
         const loadedProject = await projectService.load(project, projectToken);
         dispatch(loadProjectAction(loadedProject));
         return loadedProject;
-        
     };
 }
 
@@ -97,12 +96,11 @@ export function saveProject(
         dispatch(saveProjectAction(savedProject));
 
         // Reload project after save actions
-        try{
+        try {
             await loadProject(savedProject)(dispatch, getState);
-        } catch(e) {
+        } catch (e) {
             console.warn("Could not load project (on save project)");
         }
-        
 
         return savedProject;
     };

--- a/src/redux/actions/projectActions.ts
+++ b/src/redux/actions/projectActions.ts
@@ -58,10 +58,11 @@ export function loadProject(
         if (!projectToken) {
             throw new AppError(ErrorCode.SecurityTokenNotFound, "Security Token Not Found");
         }
-        const loadedProject = await projectService.load(project, projectToken);
 
+        const loadedProject = await projectService.load(project, projectToken);
         dispatch(loadProjectAction(loadedProject));
         return loadedProject;
+        
     };
 }
 
@@ -96,7 +97,12 @@ export function saveProject(
         dispatch(saveProjectAction(savedProject));
 
         // Reload project after save actions
-        await loadProject(savedProject)(dispatch, getState);
+        try{
+            await loadProject(savedProject)(dispatch, getState);
+        } catch(e) {
+            console.warn("Could not load project (on save project)");
+        }
+        
 
         return savedProject;
     };
@@ -123,7 +129,6 @@ export function deleteProject(
         }
 
         const decryptedProject = await projectService.load(project, projectToken);
-
         await projectService.delete(decryptedProject);
         dispatch(deleteProjectAction(decryptedProject));
     };

--- a/src/redux/actions/trackingActions.ts
+++ b/src/redux/actions/trackingActions.ts
@@ -2,7 +2,7 @@ import { Dispatch } from "redux";
 import { createPayloadAction, IPayloadAction } from "./actionCreators";
 import { ActionTypes } from "./actionTypes";
 import { ITrackingAction, TrackingActionType, createTrackingAction, TrackingAction } from "../../models/trackingAction";
-import { IRegion } from "../../models/applicationState";
+import { IRegion, AppError, ErrorCode } from "../../models/applicationState";
 import apiService from "../../services/apiService";
 
 /**
@@ -27,9 +27,13 @@ export default interface ITrackingActions {
 export function trackingSignIn(userId: number): (dispatch: Dispatch) => Promise<void> {
     return async (dispatch: Dispatch) => {
         const trackingAction = createTrackingAction(TrackingActionType.SignIn, userId);
-        await apiService.createAction(trackingAction);
-        dispatch(trackingSignInAction(trackingAction));
-        return Promise.resolve();
+        try {
+            await apiService.createAction(trackingAction)
+            dispatch(trackingSignInAction(trackingAction));
+            return Promise.resolve();
+        } catch {
+            return Promise.reject();
+        }
     };
 }
 
@@ -39,9 +43,13 @@ export function trackingSignIn(userId: number): (dispatch: Dispatch) => Promise<
 export function trackingSignOut(userId: number): (dispatch: Dispatch) => Promise<void> {
     return async (dispatch: Dispatch) => {
         const trackingAction = createTrackingAction(TrackingActionType.SignOut, userId);
-        await apiService.createAction(trackingAction);
-        dispatch(trackingSignOutAction(trackingAction));
-        return Promise.resolve();
+        try {
+            await apiService.createAction(trackingAction);
+            dispatch(trackingSignOutAction(trackingAction));
+            return Promise.resolve();
+        } catch {
+            return Promise.reject();
+        }
     };
 }
 
@@ -55,9 +63,13 @@ export function trackingImgIn(
 ): (dispatch: Dispatch) => Promise<void> {
     return async (dispatch: Dispatch) => {
         const trackingAction = createTrackingAction(TrackingActionType.ImgIn, userId, imageId, regions);
-        await apiService.createAction(trackingAction);
-        dispatch(trackingImgInAction(trackingAction));
-        return Promise.resolve();
+        try {
+            await apiService.createAction(trackingAction);
+            dispatch(trackingImgInAction(trackingAction));
+            return Promise.resolve();
+        } catch {
+            return Promise.reject();
+        }
     };
 }
 
@@ -72,9 +84,13 @@ export function trackingImgOut(
 ): (dispatch: Dispatch) => Promise<TrackingAction> {
     return async (dispatch: Dispatch) => {
         const trackingAction = createTrackingAction(TrackingActionType.ImgOut, userId, imageId, regions, isModified);
-        await apiService.createAction(trackingAction);
-        dispatch(trackingImgOutAction(trackingAction));
-        return Promise.resolve(trackingAction);
+        try {
+            await apiService.createAction(trackingAction);
+            dispatch(trackingImgOutAction(trackingAction));
+            return Promise.resolve(trackingAction);
+        } catch {
+            return Promise.reject();
+        }
     };
 }
 
@@ -84,9 +100,13 @@ export function trackingImgOut(
 export function trackingImgDelete(userId: number, imageId: string): (dispatch: Dispatch) => Promise<void> {
     return async (dispatch: Dispatch) => {
         const trackingAction = createTrackingAction(TrackingActionType.ImgDelete, userId, imageId);
-        await apiService.createAction(trackingAction);
-        dispatch(trackingImgDeleteAction(trackingAction));
-        return Promise.resolve();
+        try {
+            await apiService.createAction(trackingAction);
+            dispatch(trackingImgDeleteAction(trackingAction));
+            return Promise.resolve();
+        } catch {
+            return Promise.reject();
+        }
     };
 }
 

--- a/src/redux/actions/trackingActions.ts
+++ b/src/redux/actions/trackingActions.ts
@@ -28,7 +28,7 @@ export function trackingSignIn(userId: number): (dispatch: Dispatch) => Promise<
     return async (dispatch: Dispatch) => {
         const trackingAction = createTrackingAction(TrackingActionType.SignIn, userId);
         try {
-            await apiService.createAction(trackingAction)
+            await apiService.createAction(trackingAction);
             dispatch(trackingSignInAction(trackingAction));
             return Promise.resolve();
         } catch {

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -18,6 +18,7 @@ import { ExportAssetState } from "../providers/export/exportProvider";
 import { IExportFormat } from "vott-react";
 import apiService from "./apiService";
 import { buildTags } from "../react/components/common/tagInput/tagInput";
+import { strings } from "../common/strings";
 
 /**
  * Functions required for a project service
@@ -65,7 +66,7 @@ export default class ProjectService implements IProjectService {
                 const litters = await apiService.getLitters();
                 loadedProject.tags = buildTags(litters.data);
             } catch (e) {
-                console.warn("Unable to get litter list");
+                console.warn(strings.consoleMessages.getLitterFailed);
                 return Promise.reject();
             }
 

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -64,11 +64,11 @@ export default class ProjectService implements IProjectService {
             try {
                 const litters = await apiService.getLitters();
                 loadedProject.tags = buildTags(litters.data);
-            } catch(e) {
-                console.warn("Unable to get litter list")
+            } catch (e) {
+                console.warn("Unable to get litter list");
                 return Promise.reject();
             }
-            
+
             // Initialize active learning settings if they don't exist
             if (!loadedProject.activeLearningSettings) {
                 loadedProject.activeLearningSettings = defaultActiveLearningSettings;

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -61,9 +61,14 @@ export default class ProjectService implements IProjectService {
         try {
             const loadedProject = decryptProject(project, securityToken);
 
-            const litters = await apiService.getLitters();
-            loadedProject.tags = buildTags(litters.data);
-
+            try {
+                const litters = await apiService.getLitters();
+                loadedProject.tags = buildTags(litters.data);
+            } catch(e) {
+                console.warn("Unable to get litter list")
+                return Promise.reject();
+            }
+            
             // Initialize active learning settings if they don't exist
             if (!loadedProject.activeLearningSettings) {
                 loadedProject.activeLearningSettings = defaultActiveLearningSettings;


### PR DESCRIPTION
### INFO
There was an error that appeared during loading project.
Actually, this error occurs when the list of litters cannot be gotten after clicking a lot on the images: it provokes a timeout that is displayed, and the error is also caught but displayed as "error loading project file" (an error that can also happen). The two errors are now differentiated.

There was another error that needed to be taken cared of because it was happening a lot and shadowing the first one: when clicking a lot on the images, the actions cannot be sent and there was a rejected Promise unhandled. Now the error is caught and an message is displayed in the console.

These errors all happen when clicking rapidly on lots of images. When one of them appear, lots of them follow 💥 that is why the message is displayed in the console and not as a modal to the user.

These errors are handled but not prevented: they come from the fact that too much calls are made at the same time.

### TEST
1. Run app, open browser inspector and go to console tab.
2. Click frenetically on images thumbnails for at least 5 seconds and then wait
3. You should see warnings about sending img_in, img_out, getting litters and loading projects.
These error seem to happen more in the local version of the app.