### PR TITLE
Confirm tagger control

### DIFF
--- a/src/common/localization/en.json
+++ b/src/common/localization/en.json
@@ -233,7 +233,8 @@
             "reloadImages": "Reload Images",
             "admin": "Admin",
             "regular": "Regular",
-            "chooseEndpoint": "Choose endpoint"
+            "chooseEndpoint": "Choose endpoint",
+            "buildIdl": "Build IDL"
         },
         "videoPlayer": {
             "previousTaggedFrame": {

--- a/src/common/localization/es.json
+++ b/src/common/localization/es.json
@@ -233,7 +233,8 @@
             "reloadImages": "Recargar imágenes",
             "admin": "Admin",
             "regular": "Regular",
-            "chooseEndpoint": "Choose endpoint"
+            "chooseEndpoint": "Choose endpoint",
+            "buildIdl": "Crear IDL"
         },
         "videoPlayer": {
             "previousTaggedFrame": {

--- a/src/common/strings.ts
+++ b/src/common/strings.ts
@@ -242,6 +242,7 @@ export interface IAppStrings {
             chooseEndpoint: string;
             regular: string;
             admin: string;
+            buildIdl: string;
         };
         videoPlayer: {
             nextTaggedFrame: {

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -292,6 +292,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                                     isAdmin={this.props.auth.isAdmin}
                                     onEndpointTypeChange={this.handleEndpointTypeChange}
                                     endpointType={endpointType}
+                                    onBuildIdlButtonClick={this.onBuildIdlButtonClick}
                                 />
                             </div>
                             <div className="editor-page-content-main-body">
@@ -408,6 +409,15 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
             selectedRegions: []
         });
     };
+
+    private onBuildIdlButtonClick = async () => {
+        const images = [...this.state.images];
+        const imageNames = images.map(item => {
+            const object = { ...item };
+            return object.basename;
+        });
+        await apiService.buildIdl(imageNames)
+    }
 
     /**
      * Called when the asset side bar is resized

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -416,8 +416,8 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
             const object = { ...item };
             return object.basename;
         });
-        await apiService.buildIdl(imageNames)
-    }
+        await apiService.buildIdl(imageNames);
+    };
 
     /**
      * Called when the asset side bar is resized

--- a/src/react/components/pages/editorPage/editorToolbar.tsx
+++ b/src/react/components/pages/editorPage/editorToolbar.tsx
@@ -7,6 +7,7 @@ import { IToolbarItemProps, ToolbarItem, ToolbarItemType } from "../../toolbar/t
 import "./editorToolbar.scss";
 import { ToolbarItemName } from "../../../../registerToolbar";
 import { strings } from "../../../../common/strings";
+import { Button } from 'reactstrap'
 
 /**
  * Properties for Editor Toolbar
@@ -23,6 +24,7 @@ export interface IEditorToolbarProps {
     isAdmin: boolean;
     endpointType: number;
     onEndpointTypeChange: (event: any) => void;
+    onBuildIdlButtonClick: () => void;
 }
 
 /**
@@ -92,6 +94,14 @@ export class EditorToolbar extends React.Component<IEditorToolbarProps, IEditorT
                             <option value={0}>{strings.editorPage.toolbar.regular}</option>
                             <option value={1}>{strings.editorPage.toolbar.admin}</option>
                         </select>
+                    </div>
+                )}
+                {this.props.isAdmin && (
+                    <div style={{ marginLeft: 10 }}>
+                        <Button
+                            color={"primary"}
+                            onClick={this.props.onBuildIdlButtonClick}>{strings.editorPage.toolbar.buildIdl}
+                        </Button>
                     </div>
                 )}
             </div>

--- a/src/react/components/pages/editorPage/editorToolbar.tsx
+++ b/src/react/components/pages/editorPage/editorToolbar.tsx
@@ -7,7 +7,7 @@ import { IToolbarItemProps, ToolbarItem, ToolbarItemType } from "../../toolbar/t
 import "./editorToolbar.scss";
 import { ToolbarItemName } from "../../../../registerToolbar";
 import { strings } from "../../../../common/strings";
-import { Button } from 'reactstrap'
+import { Button } from "reactstrap";
 
 /**
  * Properties for Editor Toolbar
@@ -98,9 +98,8 @@ export class EditorToolbar extends React.Component<IEditorToolbarProps, IEditorT
                 )}
                 {this.props.isAdmin && (
                     <div style={{ marginLeft: 10 }}>
-                        <Button
-                            color={"primary"}
-                            onClick={this.props.onBuildIdlButtonClick}>{strings.editorPage.toolbar.buildIdl}
+                        <Button color={"primary"} onClick={this.props.onBuildIdlButtonClick}>
+                            {strings.editorPage.toolbar.buildIdl}
                         </Button>
                     </div>
                 )}

--- a/src/services/ApiEnum.ts
+++ b/src/services/ApiEnum.ts
@@ -5,6 +5,7 @@ export enum Api {
     LoginTestToken = "api/v1/login/test-token",
     LoginAccessToken = "api/v1/login/access-token",
     DispatcherImages = "/api/v1/dispatcher/images",
+    BuildIdl = "/api/v1/dispatcher/build_idl",
     QualityControl = "/api/v1/dispatcher/quality_control",
     ImagesWithLastAction = "/api/v1/images/with_last_action",
     Litters = "/api/v1/litter/"

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -112,7 +112,7 @@ export class ApiService implements IApiService {
     };
 
     public getImagesForQualityControl = (limit: number = 20, targetPath = null): AxiosPromise<IImageWithAction[]> => {
-        const targetPathParameter = targetPath? `&target_path=${targetPath}` : ''
+        const targetPathParameter = targetPath ? `&target_path=${targetPath}` : "";
         return this.client.put(`${Api.QualityControl}?limit=${limit}${targetPathParameter}`, { limit });
     };
 

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -116,6 +116,10 @@ export class ApiService implements IApiService {
         return this.client.put(`${Api.QualityControl}?limit=${limit}${targetPathParameter}`, { limit });
     };
 
+    public buildIdl = (imageNames: string[]): AxiosPromise<IImageWithAction[]> => {
+        return this.client.put(`${Api.BuildIdl}`, imageNames);
+    };
+
     public getImageWithLastAction = (): AxiosPromise<IImageWithAction[]> => {
         return this.client.get(Api.ImagesWithLastAction);
     };


### PR DESCRIPTION
New button "build IDL" on toolbar, that will appear only if user is an admin.
When admin clicks on the button, the corresponding endpoint is called.

How to test:
1. log in as admin on vott
2. you should see a button "Build IDL" on the toolbar
3. enable network inspect and click on the button
4. you will get a 404 as endpoint is not available on mocks yet. check the network: you should see that "build_idl" is called.