### PR TITLE
Get litters only once

### DIFF
--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -622,7 +622,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
             await this.props.actions.saveAssetMetadata(this.props.project, assetMetadata, tagsWithId);
         }
 
-        await this.props.actions.saveProject(this.props.project);
+        await this.props.actions.saveProject(this.props.project, false);
 
         const assetService = new AssetService(this.props.project);
         const childAssets = assetService.getChildAssets(rootAsset);
@@ -662,7 +662,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
             tags
         };
 
-        await this.props.actions.saveProject(project);
+        await this.props.actions.saveProject(project, false);
     };
 
     private onLockedTagsChanged = (lockedTags: string[]) => {

--- a/src/redux/actions/projectActions.ts
+++ b/src/redux/actions/projectActions.ts
@@ -22,8 +22,8 @@ import { IImageWithAction } from "../../services/apiService";
  * Actions to be performed in relation to projects
  */
 export default interface IProjectActions {
-    loadProject(project: IProject): Promise<IProject>;
-    saveProject(project: IProject): Promise<IProject>;
+    loadProject(project: IProject, buildTagsRequired?: boolean): Promise<IProject>;
+    saveProject(project: IProject, buildTagsRequired?: boolean): Promise<IProject>;
     deleteProject(project: IProject): Promise<void>;
     closeProject(): void;
     exportProject(project: IProject): Promise<void> | Promise<IExportResults>;
@@ -44,7 +44,8 @@ export default interface IProjectActions {
  * @param project - Project to load
  */
 export function loadProject(
-    project: IProject
+    project: IProject,
+    buildTagsRequired: boolean = true,
 ): (dispatch: Dispatch, getState: () => IApplicationState) => Promise<IProject> {
     return async (dispatch: Dispatch, getState: () => IApplicationState) => {
         const appState = getState();
@@ -59,7 +60,7 @@ export function loadProject(
             throw new AppError(ErrorCode.SecurityTokenNotFound, "Security Token Not Found");
         }
 
-        const loadedProject = await projectService.load(project, projectToken);
+        const loadedProject = await projectService.load(project, projectToken, buildTagsRequired);
         dispatch(loadProjectAction(loadedProject));
         return loadedProject;
     };
@@ -70,7 +71,8 @@ export function loadProject(
  * @param project - Project to save
  */
 export function saveProject(
-    project: IProject
+    project: IProject,
+    buildTagsRequired: boolean = true
 ): (dispatch: Dispatch, getState: () => IApplicationState) => Promise<IProject> {
     return async (dispatch: Dispatch, getState: () => IApplicationState) => {
         const appState = getState();
@@ -97,7 +99,7 @@ export function saveProject(
 
         // Reload project after save actions
         try {
-            await loadProject(savedProject)(dispatch, getState);
+            await loadProject(savedProject, buildTagsRequired)(dispatch, getState);
         } catch (e) {
             console.warn("Could not load project (on save project)");
         }

--- a/src/redux/actions/projectActions.ts
+++ b/src/redux/actions/projectActions.ts
@@ -45,7 +45,7 @@ export default interface IProjectActions {
  */
 export function loadProject(
     project: IProject,
-    buildTagsRequired: boolean = true,
+    buildTagsRequired: boolean = true
 ): (dispatch: Dispatch, getState: () => IApplicationState) => Promise<IProject> {
     return async (dispatch: Dispatch, getState: () => IApplicationState) => {
         const appState = getState();

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -57,19 +57,23 @@ export default class ProjectService implements IProjectService {
      * @param securityToken The security token used to decrypt sensitive project settings
      * @param buildTagsRequired If project is loaded for the first time, tags need to be built
      */
-    public async load(project: IProject, securityToken: ISecurityToken, buildTagsRequired: boolean = true): Promise<IProject> {
+    public async load(
+        project: IProject,
+        securityToken: ISecurityToken,
+        buildTagsRequired: boolean = true
+    ): Promise<IProject> {
         Guard.null(project);
 
         try {
             const loadedProject = decryptProject(project, securityToken);
-            if(buildTagsRequired){
-               try {
-                const litters = await apiService.getLitters();
-                loadedProject.tags = buildTags(litters.data);
+            if (buildTagsRequired) {
+                try {
+                    const litters = await apiService.getLitters();
+                    loadedProject.tags = buildTags(litters.data);
                 } catch (e) {
                     console.warn(strings.consoleMessages.getLitterFailed);
                     return Promise.reject();
-                } 
+                }
             }
 
             // Initialize active learning settings if they don't exist


### PR DESCRIPTION
Prevent litter endpoint to be called every time the project is saved

How to test:
- run vott and login: the tags should appear on the right
- open network inspect
- change images and add some regions
=> there should be no call to the litter endpoint