### PR TITLE
Features for admin and delete most of the img_out

### DIFF
--- a/src/models/trackingAction.ts
+++ b/src/models/trackingAction.ts
@@ -19,7 +19,7 @@ export interface ITrackingAction {
  */
 export enum TrackingActionType {
     ImgIn = "img_in",
-    ImgOut = "img_out",
+    ImgOut = "img_validate",
     ImgDelete = "img_delete",
     SignOut = "logout",
     SignIn = "login"

--- a/src/react/components/pages/editorPage/editorPage.scss
+++ b/src/react/components/pages/editorPage/editorPage.scss
@@ -290,12 +290,24 @@ canvas {
   text-shadow: 0px 0px 4px #000;
 }
 
-.badge-deleted,
-.badge-validated {
+.badge-deleted {
     color: #fff;
     position: absolute;
     z-index: 2;
     left: 0.5em;
+    top: 0.5em;
+    text-shadow: 0px 0px 4px #000;
+}
+
+.badge-off {
+    opacity: 30%;
+}
+
+.badge-validated {
+    color: #fff;
+    position: absolute;
+    z-index: 2;
+    left: 3em;
     top: 0.5em;
     text-shadow: 0px 0px 4px #000;
 }

--- a/src/react/components/pages/editorPage/editorPage.scss
+++ b/src/react/components/pages/editorPage/editorPage.scss
@@ -290,6 +290,20 @@ canvas {
   text-shadow: 0px 0px 4px #000;
 }
 
+.badge-send {
+  color: #fff;
+  position: absolute;
+  z-index: 2;
+  right: 0.5em;
+  bottom: 0.5em;
+  text-shadow: 0px 0px 4px #000;
+}
+
+.badge-send {
+  background-color: rgba(white, 0.9);
+  border: 1px solid $lighter-2;
+}
+
 .badge-deleted {
     color: #fff;
     position: absolute;
@@ -299,8 +313,30 @@ canvas {
     text-shadow: 0px 0px 4px #000;
 }
 
+.badge-button-send {
+    color: #fff;
+    position: absolute;
+    z-index: 2;
+    right: 0.5em;
+    bottom: 0.5em;
+    text-shadow: 0px 0px 4px #000;
+}
+
+.badge-button-delete {
+    color: #fff;
+    position: absolute;
+    z-index: 2;
+    left: 0.5em;
+    bottom: 0.5em;
+    text-shadow: 0px 0px 4px #000;
+}
+
 .badge-off {
     opacity: 30%;
+}
+
+.green-icon {
+  color: lightskyblue;
 }
 
 .badge-validated {

--- a/src/react/components/pages/editorPage/editorPage.scss
+++ b/src/react/components/pages/editorPage/editorPage.scss
@@ -322,15 +322,6 @@ canvas {
     text-shadow: 0px 0px 4px #000;
 }
 
-.badge-button-delete {
-    color: #fff;
-    position: absolute;
-    z-index: 2;
-    left: 0.5em;
-    bottom: 0.5em;
-    text-shadow: 0px 0px 4px #000;
-}
-
 .badge-off {
     opacity: 30%;
 }
@@ -360,12 +351,10 @@ canvas {
 
 .badge-deleted {
   background-color: rgba(red, 0.9);
-  border: 1px solid $lighter-2;
 }
 
 .badge-validated {
   background-color: rgba(blue, 0.9);
-  border: 1px solid $lighter-2;
 }
 
 .Resizer {

--- a/src/react/components/pages/editorPage/editorPage.test.tsx
+++ b/src/react/components/pages/editorPage/editorPage.test.tsx
@@ -206,7 +206,7 @@ describe("Editor Page Component", () => {
             }),
             []
         );
-        expect(saveProjectSpy).toBeCalledWith(expect.objectContaining(partialProject));
+        expect(saveProjectSpy).toBeCalledWith(expect.objectContaining(partialProject), false);
     });
 
     it("sets page state to invalid when edited asset includes un-tagged regions", async () => {
@@ -355,7 +355,7 @@ describe("Editor Page Component", () => {
             }),
             []
         );
-        expect(saveProjectSpy).toBeCalledWith(expect.objectContaining(partialProject));
+        expect(saveProjectSpy).toBeCalledWith(expect.objectContaining(partialProject), false);
     });
 
     it("When an image is updated the asset metadata is updated", async () => {

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -42,9 +42,10 @@ import Alert from "../../common/alert/alert";
 import Confirm from "../../common/confirm/confirm";
 import { ActiveLearningService } from "../../../../services/activeLearningService";
 import { toast } from "react-toastify";
+import { TrackingActionType } from "../../../../models/trackingAction";
 import ITrackingActions, * as trackingActions from "../../../../redux/actions/trackingActions";
 import { MagnifierModalMessage } from "./MagnifierModalMessage";
-import apiService, { ILitter, IImageWithAction } from "../../../../services/apiService";
+import apiService, { IActionRequest, ILitter, IImageWithAction } from "../../../../services/apiService";
 import CanvasHelpers from "./canvasHelpers";
 import { mapTrackingActionToApiBody } from "../../../../services/ApiMapper";
 
@@ -180,19 +181,6 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
             await this.props.actions.loadProject(project);
         }
         this.activeLearningService = new ActiveLearningService(this.props.project.activeLearningSettings);
-        try {
-            window.onbeforeunload = () => {
-                const { selectedAsset } = this.state;
-                this.props.trackingActions.trackingImgOut(
-                    this.props.auth.userId,
-                    selectedAsset.asset.name,
-                    selectedAsset.regions,
-                    this.isAssetModified()
-                );
-            };
-        } catch (e) {
-            console.warn(strings.consoleMessages.imgOutFailed);
-        }
         const litters = await apiService.getLitters();
         this.setState({
             litters: litters.data
@@ -280,6 +268,8 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                             selectedAsset={selectedAsset ? selectedAsset.asset : null}
                             onBeforeAssetSelected={this.onBeforeAssetSelected}
                             onAssetSelected={this.selectAsset}
+                            onSendButtonPressed={this.onSendButtonPressed}
+                            onDelButtonPressed={this.handleDeletePictureClick}
                             thumbnailSize={this.state.thumbnailSize}
                         />
                     </div>
@@ -781,7 +771,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
         } else {
             await this.selectAsset(this.state.assets[Math.max(0, currentIndex - 1)]);
         }
-    };
+    }; 
 
     private onBeforeAssetSelected = (): boolean => {
         if (!this.state.isValid) {
@@ -791,9 +781,81 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
         return this.state.isValid;
     };
 
+    private async deletePicture() {
+        try {
+            const { selectedAsset, assets } = this.state;
+            const newAssets = [...assets];
+            const indexAssetToRemove = newAssets.findIndex((asset: IAsset) => {
+                return asset.id === selectedAsset.asset.id;
+            });
+
+            
+            newAssets.splice(indexAssetToRemove, 1);
+            if (newAssets.length) {
+                const previousIndex = indexAssetToRemove - 1;
+                const assetToSelect =
+                    newAssets[previousIndex] !== undefined ? newAssets[previousIndex] : newAssets[indexAssetToRemove];
+                if (assetToSelect !== undefined) {
+                    this.selectAsset(assetToSelect);
+                } else if (newAssets.length > 0) {
+                    this.selectAsset(newAssets[0]);
+                }
+            }
+            this.setState({
+                assets: newAssets
+            });
+        } catch (error) {
+            toast.error(strings.editorPage.deletePictureError);
+        } finally {
+            this.forceUpdate();
+        }
+    }
+
+    private onSendButtonPressed = async (): Promise<void> => {
+        // if all regions have been tagged
+        if (this.onBeforeAssetSelected){
+            const { selectedAsset } = this.state;
+            const { auth, trackingActions } = this.props;
+            if (selectedAsset && selectedAsset.asset) {
+                try {
+                    await trackingActions.trackingImgOut(
+                        auth.userId,
+                        selectedAsset.asset.name,
+                        selectedAsset.regions,
+                        this.isAssetModified()
+                    );
+                    // if admin we update the bagdes, else we juste remove the image
+                    if(this.props.auth.isAdmin){
+
+                        if (selectedAsset && selectedAsset.asset) {
+                            const name = selectedAsset.asset.name;
+                            const images = [...this.state.images];
+                            const changedImages = images.map(item => {
+                                const object = { ...item };
+                                if (object.basename === name) {
+                                    object.is_validated = true;
+                                }
+                                return object;
+                            });
+                            this.setState({
+                                images: changedImages
+                            });
+                            this.saveImages(changedImages);
+                            this.forceUpdate()
+                        }
+                    } else {
+                        this.deletePicture()
+                    }
+                } catch (e) {
+                    console.warn(strings.consoleMessages.imgOutFailed);
+                }
+            }
+        }
+    }
+
     private selectAsset = async (asset: IAsset): Promise<void> => {
-        const { selectedAsset, isValid, selectedAssetBase } = this.state;
-        const { auth, trackingActions, actions, project } = this.props;
+        const { selectedAsset, isValid } = this.state;
+        const { auth, actions, project } = this.props;
         // Nothing to do if we are already on the same asset.
         if (selectedAsset && selectedAsset.asset.id === asset.id) {
             return;
@@ -808,20 +870,20 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
          * Track user leaves the image
          */
         if (selectedAsset && selectedAsset.asset) {
-            try {
-                const imgOut = await trackingActions.trackingImgOut(
-                    auth.userId,
-                    selectedAsset.asset.name,
-                    selectedAsset.regions,
-                    this.isAssetModified()
-                );
+                const imgOut: IActionRequest = {
+                    user_id: auth.userId,
+                    image_basename: selectedAsset.asset.name,
+                    regions: selectedAsset.regions,
+                    is_modified: this.isAssetModified(),
+                    type: TrackingActionType.ImgOut,
+                }
 
                 const name = selectedAsset.asset.name;
                 const images = [...this.state.images];
                 const changedImages = images.map(item => {
                     const object = { ...item };
                     if (object.basename === name) {
-                        object.last_action = mapTrackingActionToApiBody(imgOut);
+                        object.last_action = imgOut;
                     }
                     return object;
                 });
@@ -829,9 +891,6 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                     images: changedImages
                 });
                 this.saveImages(changedImages);
-            } catch (e) {
-                console.warn(strings.consoleMessages.imgOutFailed);
-            }
         }
 
         const assetMetadata = await actions.loadAssetMetadata(project, asset);
@@ -854,15 +913,6 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                 await this.onAssetMetadataChanged(assetMetadata);
             }
         );
-
-        /**
-         * Track user enters on the image
-         */
-        try {
-            await trackingActions.trackingImgIn(auth.userId, assetMetadata.asset.name, assetMetadata.regions);
-        } catch (e) {
-            console.warn(strings.consoleMessages.imgInFailed);
-        }
     };
 
     private isAssetModified = (): boolean => {
@@ -943,34 +993,29 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
         this.reloadImagesConfirm.current.open();
     }
 
-    private async handleDeletePictureClick() {
-        try {
-            const { auth, trackingActions } = this.props;
-            const { selectedAsset, assets } = this.state;
-            const newAssets = [...assets];
-            const indexAssetToRemove = newAssets.findIndex((asset: IAsset) => {
-                return asset.id === selectedAsset.asset.id;
-            });
-
-            await trackingActions.trackingImgDelete(auth.userId, selectedAsset.asset.name);
-            newAssets.splice(indexAssetToRemove, 1);
-            if (newAssets.length) {
-                const previousIndex = indexAssetToRemove - 1;
-                const assetToSelect =
-                    newAssets[previousIndex] !== undefined ? newAssets[previousIndex] : newAssets[indexAssetToRemove];
-                if (assetToSelect !== undefined) {
-                    this.selectAsset(assetToSelect);
-                } else if (newAssets.length > 0) {
-                    this.selectAsset(newAssets[0]);
-                }
+    private handleDeletePictureClick = async () => {
+        const { selectedAsset } = this.state;
+        const { auth, trackingActions } = this.props;
+        await trackingActions.trackingImgDelete(auth.userId, selectedAsset.asset.name);
+        if(this.props.auth.isAdmin) {
+            if (selectedAsset && selectedAsset.asset) {
+                const name = selectedAsset.asset.name;
+                const images = [...this.state.images];
+                const changedImages = images.map(item => {
+                    const object = { ...item };
+                    if (object.basename === name) {
+                        object.is_deleted = true;
+                    }
+                    return object;
+                });
+                this.setState({
+                    images: changedImages
+                });
+                this.saveImages(changedImages);
+                this.forceUpdate()
             }
-            this.setState({
-                assets: newAssets
-            });
-        } catch (error) {
-            toast.error(strings.editorPage.deletePictureError);
-        } finally {
-            this.forceUpdate();
+        } else {
+            this.deletePicture();
         }
     }
 }

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -811,16 +811,16 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
         }
     }
 
-
     /**
      * Calls validate image api and update image list
-     */ 
+     */
+
     private onValidate = async (isValidated: boolean): Promise<void> => {
         const { selectedAsset } = this.state;
         if (selectedAsset && selectedAsset.asset) {
             if (selectedAsset && selectedAsset.asset) {
                 const name = selectedAsset.asset.name;
-                const image = await apiService.validateImage(isValidated, name)
+                const image = await apiService.validateImage(isValidated, name);
                 const images = [...this.state.images];
                 const changedImages = images.map(item => {
                     const object = { ...item };
@@ -853,7 +853,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                     );
                     // if admin we update the bagdes, else we juste remove the image
                     if (this.props.auth.isAdmin) {
-                        this.onValidate(true)
+                        this.onValidate(true);
                     } else {
                         this.deletePicture();
                     }
@@ -1006,17 +1006,18 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
 
     /**
      * Calls delete image api and update image list
-     */ 
+     */
+
     private onDelete = async (isDeleted?: boolean) => {
         const { selectedAsset } = this.state;
-        const image = await apiService.deleteImage(isDeleted, selectedAsset.asset.name)
+        const image = await apiService.deleteImage(isDeleted, selectedAsset.asset.name);
         if (selectedAsset && selectedAsset.asset) {
             const name = selectedAsset.asset.name;
             const images = [...this.state.images];
             const changedImages = images.map(item => {
                 const object = { ...item };
                 if (object.basename === name) {
-                    return image.data
+                    return image.data;
                 }
                 return object;
             });
@@ -1026,14 +1027,14 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
             this.saveImages(changedImages);
             this.forceUpdate();
         }
-    }
+    };
 
     private handleDeletePictureClick = async (isDeleted?: boolean) => {
         const { selectedAsset } = this.state;
         const { auth, trackingActions } = this.props;
         await trackingActions.trackingImgDelete(auth.userId, selectedAsset.asset.name);
         if (this.props.auth.isAdmin) {
-            this.onDelete(true)
+            this.onDelete(true);
         } else {
             this.deletePicture();
         }

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -771,7 +771,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
         } else {
             await this.selectAsset(this.state.assets[Math.max(0, currentIndex - 1)]);
         }
-    }; 
+    };
 
     private onBeforeAssetSelected = (): boolean => {
         if (!this.state.isValid) {
@@ -789,7 +789,6 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                 return asset.id === selectedAsset.asset.id;
             });
 
-            
             newAssets.splice(indexAssetToRemove, 1);
             if (newAssets.length) {
                 const previousIndex = indexAssetToRemove - 1;
@@ -813,7 +812,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
 
     private onSendButtonPressed = async (): Promise<void> => {
         // if all regions have been tagged
-        if (this.onBeforeAssetSelected){
+        if (this.onBeforeAssetSelected) {
             const { selectedAsset } = this.state;
             const { auth, trackingActions } = this.props;
             if (selectedAsset && selectedAsset.asset) {
@@ -825,8 +824,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                         this.isAssetModified()
                     );
                     // if admin we update the bagdes, else we juste remove the image
-                    if(this.props.auth.isAdmin){
-
+                    if (this.props.auth.isAdmin) {
                         if (selectedAsset && selectedAsset.asset) {
                             const name = selectedAsset.asset.name;
                             const images = [...this.state.images];
@@ -841,17 +839,17 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                                 images: changedImages
                             });
                             this.saveImages(changedImages);
-                            this.forceUpdate()
+                            this.forceUpdate();
                         }
                     } else {
-                        this.deletePicture()
+                        this.deletePicture();
                     }
                 } catch (e) {
                     console.warn(strings.consoleMessages.imgOutFailed);
                 }
             }
         }
-    }
+    };
 
     private selectAsset = async (asset: IAsset): Promise<void> => {
         const { selectedAsset, isValid } = this.state;
@@ -870,27 +868,27 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
          * Track user leaves the image
          */
         if (selectedAsset && selectedAsset.asset) {
-                const imgOut: IActionRequest = {
-                    user_id: auth.userId,
-                    image_basename: selectedAsset.asset.name,
-                    regions: selectedAsset.regions,
-                    is_modified: this.isAssetModified(),
-                    type: TrackingActionType.ImgOut,
-                }
+            const imgOut: IActionRequest = {
+                user_id: auth.userId,
+                image_basename: selectedAsset.asset.name,
+                regions: selectedAsset.regions,
+                is_modified: this.isAssetModified(),
+                type: TrackingActionType.ImgOut
+            };
 
-                const name = selectedAsset.asset.name;
-                const images = [...this.state.images];
-                const changedImages = images.map(item => {
-                    const object = { ...item };
-                    if (object.basename === name) {
-                        object.last_action = imgOut;
-                    }
-                    return object;
-                });
-                this.setState({
-                    images: changedImages
-                });
-                this.saveImages(changedImages);
+            const name = selectedAsset.asset.name;
+            const images = [...this.state.images];
+            const changedImages = images.map(item => {
+                const object = { ...item };
+                if (object.basename === name) {
+                    object.last_action = imgOut;
+                }
+                return object;
+            });
+            this.setState({
+                images: changedImages
+            });
+            this.saveImages(changedImages);
         }
 
         const assetMetadata = await actions.loadAssetMetadata(project, asset);
@@ -997,7 +995,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
         const { selectedAsset } = this.state;
         const { auth, trackingActions } = this.props;
         await trackingActions.trackingImgDelete(auth.userId, selectedAsset.asset.name);
-        if(this.props.auth.isAdmin) {
+        if (this.props.auth.isAdmin) {
             if (selectedAsset && selectedAsset.asset) {
                 const name = selectedAsset.asset.name;
                 const images = [...this.state.images];
@@ -1012,12 +1010,12 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                     images: changedImages
                 });
                 this.saveImages(changedImages);
-                this.forceUpdate()
+                this.forceUpdate();
             }
         } else {
             this.deletePicture();
         }
-    }
+    };
 }
 
 const styles = {

--- a/src/react/components/pages/editorPage/editorSideBar.test.tsx
+++ b/src/react/components/pages/editorPage/editorSideBar.test.tsx
@@ -16,6 +16,9 @@ describe("Editor SideBar", () => {
         const props: IEditorSideBarProps = {
             assets: testAssets,
             onAssetSelected: onSelectAssetHandler,
+            images: [],
+            endpointType: 0,
+            isAdmin: false,
         };
 
         const wrapper = createComponent(props);
@@ -28,6 +31,9 @@ describe("Editor SideBar", () => {
         const props: IEditorSideBarProps = {
             assets: testAssets,
             onAssetSelected: onSelectAssetHandler,
+            images: [],
+            endpointType: 0,
+            isAdmin: false,
         };
 
         const wrapper = createComponent(props);
@@ -42,6 +48,9 @@ describe("Editor SideBar", () => {
             assets: testAssets,
             selectedAsset: testAssets[selectedAssetIndex],
             onAssetSelected: onSelectAssetHandler,
+            images: [],
+            endpointType: 0,
+            isAdmin: false,
         };
 
         const wrapper = createComponent(props);
@@ -54,6 +63,9 @@ describe("Editor SideBar", () => {
             assets: testAssets,
             selectedAsset: null,
             onAssetSelected: onSelectAssetHandler,
+            images: [],
+            endpointType: 0,
+            isAdmin: false,
         };
 
         const wrapper = createComponent(props);
@@ -77,6 +89,9 @@ describe("Editor SideBar", () => {
             assets: testAssets,
             selectedAsset: testAssets[0],
             onAssetSelected: onSelectAssetHandler,
+            images: [],
+            endpointType: 0,
+            isAdmin: false,
         };
 
         const wrapper = createComponent(props);
@@ -114,6 +129,9 @@ describe("Editor SideBar", () => {
                 width: 175,
                 height: 155,
             },
+            images: [],
+            endpointType: 0,
+            isAdmin: false,
         };
 
         const wrapper = createComponent(props);

--- a/src/react/components/pages/editorPage/editorSideBar.tsx
+++ b/src/react/components/pages/editorPage/editorSideBar.tsx
@@ -167,18 +167,14 @@ export default class EditorSideBar extends React.Component<IEditorSideBarProps, 
     private renderBadgesFromImageState = (image: IImageWithAction): JSX.Element => {
         return (
             <>
-                <span
-                    title={strings.editorPage.visited}
-                    className={image.is_deleted ? "badge badge-deleted" : "badge badge-deleted badge-off"}
-                >
+                <button className={image.is_deleted ? "badge badge-deleted" : "badge badge-deleted badge-off"}
+                    onClick={this.props.onDelButtonPressed}>
                     <i className="far fa-trash-alt"></i>
-                </span>
-                <span
-                    title={strings.editorPage.visited}
-                    className={image.is_validated ? "badge badge-validated" : "badge badge-validated badge-off"}
-                >
+                </button>
+                <button className={image.is_validated ? "badge badge-validated" : "badge badge-validated badge-off"}
+                    >
                     <i className="far fa-check-circle"></i>
-                </span>
+                </button>
             </>
         );
     };
@@ -186,18 +182,9 @@ export default class EditorSideBar extends React.Component<IEditorSideBarProps, 
     private renderButtons = (asset: IAsset): JSX.Element => {
         return (
             <>
-            <button
-                className={"badge badge-button-send"}
-                onClick={this.props.onSendButtonPressed}>
-                send
-            </button>
-            {this.props.isAdmin &&
-                <button
-                    className={"badge badge-button-delete"}
-                    onClick={this.props.onDelButtonPressed}>
-                    del
+                <button className={"badge badge-button-send"} onClick={this.props.onSendButtonPressed}>
+                    send
                 </button>
-            }
             </>
         );
     };

--- a/src/react/components/pages/editorPage/editorSideBar.tsx
+++ b/src/react/components/pages/editorPage/editorSideBar.tsx
@@ -175,7 +175,10 @@ export default class EditorSideBar extends React.Component<IEditorSideBarProps, 
                     <i className="far fa-trash-alt"></i>
                 </button>
                 <button className={image.is_validated ? "badge badge-validated" : "badge badge-validated badge-off"}>
-                    <i className="far fa-check-circle" onClick={() => this.props.onValidateButtonPressed(!image.is_validated)}></i>
+                    <i
+                        className="far fa-check-circle"
+                        onClick={() => this.props.onValidateButtonPressed(!image.is_validated)}
+                    ></i>
                 </button>
             </>
         );

--- a/src/react/components/pages/editorPage/editorSideBar.tsx
+++ b/src/react/components/pages/editorPage/editorSideBar.tsx
@@ -1,10 +1,9 @@
 import React from "react";
 import { AutoSizer, List } from "react-virtualized";
-import { IAsset, AssetState, ImageState, ISize } from "../../../../models/applicationState";
+import { IAsset, AssetState, ISize } from "../../../../models/applicationState";
 import { AssetPreview } from "../../common/assetPreview/assetPreview";
 import { strings } from "../../../../common/strings";
 import { IImageWithAction } from "../../../../services/apiService";
-import { EnpointType } from "../editorPage/editorPage";
 
 /**
  * Properties for Editor Side Bar
@@ -18,6 +17,8 @@ export interface IEditorSideBarProps {
     images: IImageWithAction[];
     onAssetSelected: (asset: IAsset) => void;
     onBeforeAssetSelected?: () => boolean;
+    onSendButtonPressed: () => void;
+    onDelButtonPressed: () => void;
     selectedAsset?: IAsset;
     thumbnailSize?: ISize;
     endpointType: number;
@@ -128,6 +129,7 @@ export default class EditorSideBar extends React.Component<IEditorSideBarProps, 
                     {this.renderBadges(asset)}
                     {image && this.props.isAdmin === true && this.renderBadgesFromImageState(image)}
                     <AssetPreview asset={asset} />
+                    {image && this.renderButtons(asset)}
                 </div>
                 <div className="asset-item-metadata">
                     <span className="asset-filename" title={asset.name}>
@@ -160,19 +162,44 @@ export default class EditorSideBar extends React.Component<IEditorSideBarProps, 
             default:
                 return null;
         }
-    }
+    };
 
     private renderBadgesFromImageState = (image: IImageWithAction): JSX.Element => {
         return (
             <>
-                <span title={strings.editorPage.visited} className={image.is_deleted?"badge badge-deleted":"badge badge-deleted badge-off"}>
+                <span
+                    title={strings.editorPage.visited}
+                    className={image.is_deleted ? "badge badge-deleted" : "badge badge-deleted badge-off"}
+                >
                     <i className="far fa-trash-alt"></i>
                 </span>
-                <span title={strings.editorPage.visited} className={image.is_validated?"badge badge-validated":"badge badge-validated badge-off"}>
+                <span
+                    title={strings.editorPage.visited}
+                    className={image.is_validated ? "badge badge-validated" : "badge badge-validated badge-off"}
+                >
                     <i className="far fa-check-circle"></i>
                 </span>
             </>
-        )
+        );
+    };
+
+    private renderButtons = (asset: IAsset): JSX.Element => {
+        return (
+            <>
+            <button
+                className={"badge badge-button-send"}
+                onClick={this.props.onSendButtonPressed}>
+                send
+            </button>
+            {this.props.isAdmin &&
+                <button
+                    className={"badge badge-button-delete"}
+                    onClick={this.props.onDelButtonPressed}>
+                    del
+                </button>
+            }
+            </>
+        );
     };
 
     private getAssetCssClassNames = (asset: IAsset, selectedAsset: IAsset = null): string => {

--- a/src/react/components/pages/editorPage/editorSideBar.tsx
+++ b/src/react/components/pages/editorPage/editorSideBar.tsx
@@ -18,7 +18,8 @@ export interface IEditorSideBarProps {
     onAssetSelected: (asset: IAsset) => void;
     onBeforeAssetSelected?: () => boolean;
     onSendButtonPressed: () => void;
-    onDelButtonPressed: () => void;
+    onDelButtonPressed: (isDeleted: boolean) => void;
+    onValidateButtonPressed: (isValidated: boolean) => void;
     selectedAsset?: IAsset;
     thumbnailSize?: ISize;
     endpointType: number;
@@ -167,13 +168,14 @@ export default class EditorSideBar extends React.Component<IEditorSideBarProps, 
     private renderBadgesFromImageState = (image: IImageWithAction): JSX.Element => {
         return (
             <>
-                <button className={image.is_deleted ? "badge badge-deleted" : "badge badge-deleted badge-off"}
-                    onClick={this.props.onDelButtonPressed}>
+                <button
+                    className={image.is_deleted ? "badge badge-deleted" : "badge badge-deleted badge-off"}
+                    onClick={() => this.props.onDelButtonPressed(!image.is_deleted)}
+                >
                     <i className="far fa-trash-alt"></i>
                 </button>
-                <button className={image.is_validated ? "badge badge-validated" : "badge badge-validated badge-off"}
-                    >
-                    <i className="far fa-check-circle"></i>
+                <button className={image.is_validated ? "badge badge-validated" : "badge badge-validated badge-off"}>
+                    <i className="far fa-check-circle" onClick={() => this.props.onValidateButtonPressed(!image.is_validated)}></i>
                 </button>
             </>
         );

--- a/src/react/components/pages/editorPage/editorSideBar.tsx
+++ b/src/react/components/pages/editorPage/editorSideBar.tsx
@@ -160,24 +160,19 @@ export default class EditorSideBar extends React.Component<IEditorSideBarProps, 
             default:
                 return null;
         }
-    };
+    }
 
     private renderBadgesFromImageState = (image: IImageWithAction): JSX.Element => {
-        if (image.is_deleted) {
-            return (
-                <span title={strings.editorPage.visited} className="badge badge-deleted">
+        return (
+            <>
+                <span title={strings.editorPage.visited} className={image.is_deleted?"badge badge-deleted":"badge badge-deleted badge-off"}>
                     <i className="far fa-trash-alt"></i>
                 </span>
-            );
-        } else if (image.is_validated) {
-            return (
-                <span title={strings.editorPage.visited} className="badge badge-validated">
+                <span title={strings.editorPage.visited} className={image.is_validated?"badge badge-validated":"badge badge-validated badge-off"}>
                     <i className="far fa-check-circle"></i>
                 </span>
-            );
-        } else {
-            return null;
-        }
+            </>
+        )
     };
 
     private getAssetCssClassNames = (asset: IAsset, selectedAsset: IAsset = null): string => {

--- a/src/redux/actions/projectActions.test.ts
+++ b/src/redux/actions/projectActions.test.ts
@@ -52,7 +52,7 @@ describe("Project Redux Actions", () => {
             payload: project
         });
         expect(result).toEqual(project);
-        expect(projectServiceMock.prototype.load).toBeCalledWith(project, projectToken);
+        expect(projectServiceMock.prototype.load).toBeCalledWith(project, projectToken, true);
     });
 
     it("Save Project action calls project service and dispatches redux action", async () => {
@@ -77,7 +77,7 @@ describe("Project Redux Actions", () => {
         });
         expect(result).toEqual(project);
         expect(projectServiceMock.prototype.save).toBeCalledWith(project, projectToken);
-        expect(projectServiceMock.prototype.load).toBeCalledWith(project, projectToken);
+        expect(projectServiceMock.prototype.load).toBeCalledWith(project, projectToken, true);
     });
 
     it("Save Project action correctly add project version", async () => {

--- a/src/redux/actions/trackingActions.test.ts
+++ b/src/redux/actions/trackingActions.test.ts
@@ -72,7 +72,7 @@ describe("Tracking Redux Actions", () => {
 
     it("Img delete tracking action dispatches redux action", async () => {
         await trackingActions.trackingImgDelete(1, "1")(store.dispatch);
-        const trackingObject: ITrackingAction = createTrackingAction(TrackingActionType.ImgDelete, 1, "1");
+        const trackingObject: ITrackingAction = createTrackingAction(TrackingActionType.ImgDelete, 1, "1", [], true);
         const actions = store.getActions();
 
         expect(actions.length).toEqual(1);

--- a/src/redux/actions/trackingActions.ts
+++ b/src/redux/actions/trackingActions.ts
@@ -110,7 +110,7 @@ export function trackingImgOut(
  */
 export function trackingImgDelete(userId: number, imageBasename: string): (dispatch: Dispatch) => Promise<void> {
     return async (dispatch: Dispatch) => {
-        const trackingAction = createTrackingAction(TrackingActionType.ImgDelete, userId, imageBasename);
+        const trackingAction = createTrackingAction(TrackingActionType.ImgDelete, userId, imageBasename, [], true);
         try {
             await apiService.createAction(trackingAction);
             dispatch(trackingImgDeleteAction(trackingAction));

--- a/src/services/ApiEnum.ts
+++ b/src/services/ApiEnum.ts
@@ -8,5 +8,7 @@ export enum Api {
     BuildIdl = "/api/v1/dispatcher/build_idl",
     QualityControl = "/api/v1/dispatcher/quality_control",
     ImagesWithLastAction = "/api/v1/images/with_last_action",
-    Litters = "/api/v1/litter/"
+    Litters = "/api/v1/litter/",
+    ValidateImage = "/api/v1/images/validate/",
+    DeleteImage = "/api/v1/images/flag_delete/"
 }

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -128,7 +128,6 @@ export class ApiService implements IApiService {
         return this.client.put(`${Api.DeleteImage}${imageBasename}?is_deleted=${isDeleted}`);
     };
 
-
     public getImageWithLastAction = (): AxiosPromise<IImageWithAction[]> => {
         return this.client.get(Api.ImagesWithLastAction);
     };

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -120,6 +120,15 @@ export class ApiService implements IApiService {
         return this.client.put(`${Api.BuildIdl}`, imageNames);
     };
 
+    public validateImage = (isValidated: boolean, imageBasename: string): AxiosPromise<IImageWithAction> => {
+        return this.client.put(`${Api.ValidateImage}${imageBasename}?is_validated=${isValidated}`);
+    };
+
+    public deleteImage = (isDeleted: boolean, imageBasename: string): AxiosPromise<IImageWithAction> => {
+        return this.client.put(`${Api.DeleteImage}${imageBasename}?is_deleted=${isDeleted}`);
+    };
+
+
     public getImageWithLastAction = (): AxiosPromise<IImageWithAction[]> => {
         return this.client.get(Api.ImagesWithLastAction);
     };

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -25,7 +25,7 @@ interface IUserCredentials {
 
 export interface IActionRequest {
     type: string;
-    timestamp: string;
+    timestamp?: string;
     regions: IRegion[];
     is_modified: boolean;
     user_id: number;


### PR DESCRIPTION
Added features for admin and changed 

**As all users:**
- If I check or tag several images without clicking on « send », the regions are kept but nothing is sent to the backend
- If I click on « send » but a region was not tagged, there is an error message

**As a normal user:**
- If I click on « send » and everything’s good, the image is sent to the backend with the img_validate action **and the images is removed from the list**
- If I delete a picture from toolbar, it is removed from the list and the action img_delete is sent

**As an admin:**
- If click on « send » and everything’s good, the image is sent to the backend with the img_validate action, the validate api endpoint is called and the image is updated (badge should change)
- If I click on the red trash badge, I will switch the deleted state of the image without sending any action
- If I click on the blue tick badge, I will switch the validate state of the image without sending any action
- If I delete a picture from toolbar, the action img_delete is sent and the image is updated (badge should change)
- None of the images are ever removed from the list
⚠️ You have to select the picture **before** clicking on a badge trash or tick, or the action will be perform on the wrong picture

View of the thumbnails as admin:

![Capture d’écran 2020-06-10 à 10 42 04](https://user-images.githubusercontent.com/18330745/84246555-1396eb80-ab07-11ea-824b-ed1a7a8e0ba8.png)

