### PR TITLE
Hide tags

### DIFF
--- a/src/common/localization/en.json
+++ b/src/common/localization/en.json
@@ -258,7 +258,9 @@
         "tags": {
             "hotKey": {
                 "apply": "Apply Tag with Hot Key",
-                "lock": "Lock Tag with Hot Key"
+                "lock": "Lock Tag with Hot Key",
+                "hide": "Hide regions with Hot Key",
+                "show": "Show regions with Hot Key"
             },
             "rename": {
                 "title": "Rename Tag",

--- a/src/common/localization/es.json
+++ b/src/common/localization/es.json
@@ -258,7 +258,9 @@
         "tags": {
             "hotKey": {
                 "apply": "Aplicar etiqueta con tecla de acceso rápido",
-                "lock": "Bloquear etiqueta con tecla de acceso rápido"
+                "lock": "Bloquear etiqueta con tecla de acceso rápido",
+                "hide": "Ocultar regiones con tecla de acceso rápido",
+                "show": "Mostrar regiones con tecla de acceso rápido"
             },
             "rename": {
                 "title": "Cambiar el nombre de la etiqueta",

--- a/src/common/strings.ts
+++ b/src/common/strings.ts
@@ -267,6 +267,8 @@ export interface IAppStrings {
             hotKey: {
                 apply: string;
                 lock: string;
+                hide: string;
+                show: string;
             };
             rename: {
                 title: string;

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -559,7 +559,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
             this.setState({ pressedKeys: [] });
         }, 500)();
     };
-    
+
     private handleCtrlTagHotKey = (event: KeyboardEvent): void => {
         const tag = this.getTagFromKeyboardEvent(event);
         if (tag) {

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -114,6 +114,8 @@ export interface IEditorPageState {
     images: IImageWithAction[];
     imageNumber: number;
     endpointType: number;
+    pressingHideImage: boolean;
+    currentRegions: IRegion[];
 }
 
 function mapStateToProps(state: IApplicationState) {
@@ -161,7 +163,9 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
         pressedKeys: [],
         images: [],
         imageNumber: 20,
-        endpointType: EnpointType.REGULAR
+        endpointType: EnpointType.REGULAR,
+        pressingHideImage: false,
+        currentRegions: []
     };
 
     private activeLearningService: ActiveLearningService = null;
@@ -238,18 +242,20 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                         />
                     );
                 })}
-                {[...project.tags.keys()].map(index => {
-                    return (
-                        <KeyboardBinding
-                            displayName={strings.editorPage.tags.hotKey.lock}
-                            key={index}
-                            keyEventType={KeyEventType.KeyDown}
-                            accelerators={[`CmdOrCtrl+${index}`]}
-                            icon={"fa-lock"}
-                            handler={this.handleCtrlTagHotKey}
-                        />
-                    );
-                })}
+                <KeyboardBinding
+                        displayName={'ouaaa'}
+                        keyEventType={KeyEventType.KeyDown}
+                        accelerators={['h', 'H']}
+                        icon={"fa-tag"}
+                        handler={this.hideRegions}
+                />
+                <KeyboardBinding
+                        displayName={'ou'}
+                        keyEventType={KeyEventType.KeyUp}
+                        accelerators={['h', 'H']}
+                        icon={"fa-tag"}
+                        handler={this.showRegions}
+                />
                 <SplitPane
                     split="vertical"
                     defaultSize={this.state.thumbnailSize.width}
@@ -379,6 +385,23 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                 />
             </div>
         );
+    }
+
+    private hideRegions = () => {
+        if(!this.state.pressingHideImage){
+            this.setState({ pressingHideImage: true })
+            const tmpRegions = this.state.selectedAsset.regions;
+            const hiddenRegionsAsset = {...this.state.selectedAsset, regions: []}
+            this.setState({selectedAsset: hiddenRegionsAsset, currentRegions: tmpRegions})
+        }
+    }
+
+    private showRegions = () => {
+        if(this.state.pressingHideImage){
+            this.setState({ pressingHideImage: false })
+            const previousAsset = {...this.state.selectedAsset, regions: this.state.currentRegions}
+            this.setState({selectedAsset: previousAsset,})
+        }
     }
 
     private handleEndpointTypeChange = (event: any) => {
@@ -523,13 +546,6 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
             }
             this.setState({ pressedKeys: [] });
         }, 500)();
-    };
-
-    private handleCtrlTagHotKey = (event: KeyboardEvent): void => {
-        const tag = this.getTagFromKeyboardEvent(event);
-        if (tag) {
-            this.onCtrlTagClicked(tag);
-        }
     };
 
     private onCtrlTagClicked = (tag: ITag): void => {
@@ -781,6 +797,19 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
 
         return this.state.isValid;
     };
+
+    private maskRegions = (): void => {
+        const tmpRegions = this.state.selectedAsset.regions;
+        this.setState(
+            {
+                selectedAsset:{
+                    regions: [],
+                    asset: this.state.selectedAsset.asset,
+                    version: this.state.selectedAsset.version
+                }
+            }
+        )
+    }
 
     private async deletePicture() {
         try {

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -243,18 +243,18 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                     );
                 })}
                 <KeyboardBinding
-                        displayName={'ouaaa'}
-                        keyEventType={KeyEventType.KeyDown}
-                        accelerators={['h', 'H']}
-                        icon={"fa-tag"}
-                        handler={this.hideRegions}
+                    displayName={"ouaaa"}
+                    keyEventType={KeyEventType.KeyDown}
+                    accelerators={["h", "H"]}
+                    icon={"fa-tag"}
+                    handler={this.hideRegions}
                 />
                 <KeyboardBinding
-                        displayName={'ou'}
-                        keyEventType={KeyEventType.KeyUp}
-                        accelerators={['h', 'H']}
-                        icon={"fa-tag"}
-                        handler={this.showRegions}
+                    displayName={"ou"}
+                    keyEventType={KeyEventType.KeyUp}
+                    accelerators={["h", "H"]}
+                    icon={"fa-tag"}
+                    handler={this.showRegions}
                 />
                 <SplitPane
                     split="vertical"
@@ -388,21 +388,21 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
     }
 
     private hideRegions = () => {
-        if(!this.state.pressingHideImage){
-            this.setState({ pressingHideImage: true })
+        if (!this.state.pressingHideImage) {
+            this.setState({ pressingHideImage: true });
             const tmpRegions = this.state.selectedAsset.regions;
-            const hiddenRegionsAsset = {...this.state.selectedAsset, regions: []}
-            this.setState({selectedAsset: hiddenRegionsAsset, currentRegions: tmpRegions})
+            const hiddenRegionsAsset = { ...this.state.selectedAsset, regions: [] };
+            this.setState({ selectedAsset: hiddenRegionsAsset, currentRegions: tmpRegions });
         }
-    }
+    };
 
     private showRegions = () => {
-        if(this.state.pressingHideImage){
-            this.setState({ pressingHideImage: false })
-            const previousAsset = {...this.state.selectedAsset, regions: this.state.currentRegions}
-            this.setState({selectedAsset: previousAsset,})
+        if (this.state.pressingHideImage) {
+            this.setState({ pressingHideImage: false });
+            const previousAsset = { ...this.state.selectedAsset, regions: this.state.currentRegions };
+            this.setState({ selectedAsset: previousAsset });
         }
-    }
+    };
 
     private handleEndpointTypeChange = (event: any) => {
         const endpointType: number = Number(event.target.value);
@@ -800,16 +800,14 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
 
     private maskRegions = (): void => {
         const tmpRegions = this.state.selectedAsset.regions;
-        this.setState(
-            {
-                selectedAsset:{
-                    regions: [],
-                    asset: this.state.selectedAsset.asset,
-                    version: this.state.selectedAsset.version
-                }
+        this.setState({
+            selectedAsset: {
+                regions: [],
+                asset: this.state.selectedAsset.asset,
+                version: this.state.selectedAsset.version
             }
-        )
-    }
+        });
+    };
 
     private async deletePicture() {
         try {

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -242,15 +242,27 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                         />
                     );
                 })}
+                {[...project.tags.keys()].map(index => {
+                    return (
+                        <KeyboardBinding
+                            displayName={strings.editorPage.tags.hotKey.lock}
+                            key={index}
+                            keyEventType={KeyEventType.KeyDown}
+                            accelerators={[`CmdOrCtrl+${index}`]}
+                            icon={"fa-lock"}
+                            handler={this.handleCtrlTagHotKey}
+                        />
+                    );
+                })}
                 <KeyboardBinding
-                    displayName={"ouaaa"}
+                    displayName={strings.editorPage.tags.hotKey.hide}
                     keyEventType={KeyEventType.KeyDown}
                     accelerators={["h", "H"]}
                     icon={"fa-tag"}
                     handler={this.hideRegions}
                 />
                 <KeyboardBinding
-                    displayName={"ou"}
+                    displayName={strings.editorPage.tags.hotKey.show}
                     keyEventType={KeyEventType.KeyUp}
                     accelerators={["h", "H"]}
                     icon={"fa-tag"}
@@ -546,6 +558,13 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
             }
             this.setState({ pressedKeys: [] });
         }, 500)();
+    };
+    
+    private handleCtrlTagHotKey = (event: KeyboardEvent): void => {
+        const tag = this.getTagFromKeyboardEvent(event);
+        if (tag) {
+            this.onCtrlTagClicked(tag);
+        }
     };
 
     private onCtrlTagClicked = (tag: ITag): void => {

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -817,17 +817,6 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
         return this.state.isValid;
     };
 
-    private maskRegions = (): void => {
-        const tmpRegions = this.state.selectedAsset.regions;
-        this.setState({
-            selectedAsset: {
-                regions: [],
-                asset: this.state.selectedAsset.asset,
-                version: this.state.selectedAsset.version
-            }
-        });
-    };
-
     private async deletePicture() {
         try {
             const { selectedAsset, assets } = this.state;


### PR DESCRIPTION
User can hide tags by pressing 'h' key.

**Test**: run app and login, then choose an image with existing regions or tag one yourself. Maintain 'h' key pressed: the regions should be disappear. Release the key: the regions should re-appear.