### PR TITLE
Prevent delete and validate tag together

### DIFF
--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -1037,6 +1037,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
         const { auth, trackingActions } = this.props;
         if (this.props.auth.isAdmin) {
             this.onDelete(true);
+            this.onValidate(false)
         } else {
             await trackingActions.trackingImgDelete(auth.userId, selectedAsset.asset.name);
             this.deletePicture();

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -1037,7 +1037,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
         const { auth, trackingActions } = this.props;
         if (this.props.auth.isAdmin) {
             this.onDelete(true);
-            this.onValidate(false)
+            this.onValidate(false);
         } else {
             await trackingActions.trackingImgDelete(auth.userId, selectedAsset.asset.name);
             this.deletePicture();

--- a/src/react/components/pages/editorPage/editorSideBar.tsx
+++ b/src/react/components/pages/editorPage/editorSideBar.tsx
@@ -170,14 +170,28 @@ export default class EditorSideBar extends React.Component<IEditorSideBarProps, 
             <>
                 <button
                     className={image.is_deleted ? "badge badge-deleted" : "badge badge-deleted badge-off"}
-                    onClick={() => this.props.onDelButtonPressed(!image.is_deleted)}
+                    onClick={() => {
+                        if(!image.is_deleted && image.is_validated) {
+                            this.props.onDelButtonPressed(true)
+                            this.props.onValidateButtonPressed(false)
+                        } else {
+                            this.props.onDelButtonPressed(!image.is_deleted)
+                        }
+                    }} 
                 >
                     <i className="far fa-trash-alt"></i>
                 </button>
                 <button className={image.is_validated ? "badge badge-validated" : "badge badge-validated badge-off"}>
                     <i
                         className="far fa-check-circle"
-                        onClick={() => this.props.onValidateButtonPressed(!image.is_validated)}
+                        onClick={() => {
+                            if(!image.is_validated && image.is_deleted){
+                                this.props.onDelButtonPressed(false);
+                                this.props.onValidateButtonPressed(true);
+                            } else {
+                                this.props.onValidateButtonPressed(!image.is_validated)
+                            }
+                        }}
                     ></i>
                 </button>
             </>

--- a/src/react/components/pages/editorPage/editorSideBar.tsx
+++ b/src/react/components/pages/editorPage/editorSideBar.tsx
@@ -171,13 +171,13 @@ export default class EditorSideBar extends React.Component<IEditorSideBarProps, 
                 <button
                     className={image.is_deleted ? "badge badge-deleted" : "badge badge-deleted badge-off"}
                     onClick={() => {
-                        if(!image.is_deleted && image.is_validated) {
-                            this.props.onDelButtonPressed(true)
-                            this.props.onValidateButtonPressed(false)
+                        if (!image.is_deleted && image.is_validated) {
+                            this.props.onDelButtonPressed(true);
+                            this.props.onValidateButtonPressed(false);
                         } else {
-                            this.props.onDelButtonPressed(!image.is_deleted)
+                            this.props.onDelButtonPressed(!image.is_deleted);
                         }
-                    }} 
+                    }}
                 >
                     <i className="far fa-trash-alt"></i>
                 </button>
@@ -185,11 +185,11 @@ export default class EditorSideBar extends React.Component<IEditorSideBarProps, 
                     <i
                         className="far fa-check-circle"
                         onClick={() => {
-                            if(!image.is_validated && image.is_deleted){
+                            if (!image.is_validated && image.is_deleted) {
                                 this.props.onDelButtonPressed(false);
                                 this.props.onValidateButtonPressed(true);
-                            } else {
-                                this.props.onValidateButtonPressed(!image.is_validated)
+                            } else {
+                                this.props.onValidateButtonPressed(!image.is_validated);
                             }
                         }}
                     ></i>


### PR DESCRIPTION
When an admin validates a deleted image, it is un-deleted, and vice versa.

Test: click on the 'delete' badge of a validated image => the image should only be deleted. Click on 'validate' => the image should only be validated. It also works if you click on the 'delete' button of the toolbar.