### PR TITLE
803 utiliser les release versions pour tagger les images docker

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,3 @@
 REACT_APP_INSTRUMENTATION_KEY=app-key
-SUBDOMAIN=vott
-DOMAIN=cortexia.io
-TRAEFIK_PUBLIC_NETWORK=traefik-public
 REACT_APP_API_URL=https://backend.cortexia.io
 NODE_ENV=production

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,9 @@
+version: '3.7'
+
+services:
+  vott:
+    build:
+      context: .
+      args:
+        - BUILDTIME_CORTEXIA_VERSION=${BUILDTIME_CORTEXIA_VERSION}
+    image: cortexia/vott:${TAG}

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -2,13 +2,8 @@ version: '3.7'
 
 services:
   vott:
-    build:
-      context: .
-      args:
-        - BUILDTIME_CORTEXIA_VERSION=${CORTEXIA_VERSION}
     env_file : .env
-    image: cortexia/vott:${DOCKER_TAG}
-    container_name: vott
+    image: cortexia/vott:${TAG}
     deploy:
       labels:
         - "traefik.enable=true"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,25 +1,22 @@
 version: '3.7'
 
 services:
-  vott-dev:
+  vott:
     build: 
       context: ./
       dockerfile: Dockerfile-dev
       args:
-        - BUILDTIME_CORTEXIA_VERSION=${CORTEXIA_VERSION}
-    env_file:
-      - ./.env
-    environment:
-      - STACK_NAME=vott
-      - REACT_APP_INSTRUMENTATION_KEY=${REACT_APP_INSTRUMENTATION_KEY}
-      - TRAEFIK_PUBLIC_NETWORK=${TRAEFIK_PUBLIC_NETWORK}
-      - DOMAIN=local
-      - SUBDOMAIN=vott
-      - ENVIRONMENT=dev
-      - NODE_ENV=development
-      - DOCKER_TAG=latest
-      - REACT_APP_API_URL=${REACT_APP_API_URL}
+        - BUILDTIME_CORTEXIA_VERSION=${BUILDTIME_CORTEXIA_VERSION}
+    env_file : .env
+    container_name: vott
     volumes:
       - ./src:/app/src
     ports:
       - "3000:3000"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=${TRAEFIK_PUBLIC_NETWORK}"
+      - "traefik.http.routers.${STACK_NAME}.entrypoints=websecure"
+      - "traefik.http.routers.${STACK_NAME}.tls.certresolver=cloudflare"
+      - "traefik.http.routers.${STACK_NAME}.rule=Host(`${SUBDOMAIN}.${DOMAIN}`)"
+      - "traefik.http.services.${STACK_NAME}.loadbalancer.server.port=5000"

--- a/docker-compose.networks.yml
+++ b/docker-compose.networks.yml
@@ -9,10 +9,3 @@ services:
   vott:
     networks:
       - traefik
-    labels:
-      - "traefik.enable=true"
-      - "traefik.docker.network=${TRAEFIK_PUBLIC_NETWORK}"
-      - "traefik.http.routers.${STACK_NAME}.entrypoints=websecure"
-      - "traefik.http.routers.${STACK_NAME}.tls.certresolver=cloudflare"
-      - "traefik.http.routers.${STACK_NAME}.rule=Host(`${SUBDOMAIN}.${DOMAIN}`)"
-      - "traefik.http.services.${STACK_NAME}.loadbalancer.server.port=5000"

--- a/scripts/docker_build-push.sh
+++ b/scripts/docker_build-push.sh
@@ -1,0 +1,10 @@
+#! /usr/bin/env sh
+
+# Exit in case of error
+set -e
+
+TAG=${TAG} \
+BUILDTIME_CORTEXIA_VERSION=${BUILDTIME_CORTEXIA_VERSION} \
+source ./scripts/docker_build.sh
+
+docker-compose -f docker-stack.yml push

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -1,0 +1,15 @@
+#! /usr/bin/env sh
+
+# Exit in case of error
+set -e
+
+git tag -f ${TAG}
+git push --tags --force
+
+TAG=${TAG} \
+BUILDTIME_CORTEXIA_VERSION=${BUILDTIME_CORTEXIA_VERSION} \
+docker-compose \
+-f docker-compose.build.yml \
+config > docker-stack.yml
+
+docker-compose -f docker-stack.yml build

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -12,4 +12,4 @@ docker-compose \
 -f docker-compose.build.yml \
 config > docker-stack.yml
 
-docker-compose -f docker-stack.yml build
+docker-compose -f docker-stack.yml build --pull

--- a/scripts/docker_deploy.sh
+++ b/scripts/docker_deploy.sh
@@ -1,0 +1,18 @@
+#! /usr/bin/env sh
+
+# Exit in case of error
+set -e
+
+TAG=${TAG} \
+STACK_NAME=${STACK_NAME} \
+SUBDOMAIN=${SUBDOMAIN} \
+DOMAIN=${DOMAIN} \
+TRAEFIK_PUBLIC_NETWORK=${TRAEFIK_PUBLIC_NETWORK} \
+docker-compose \
+-f docker-compose.deploy.yml \
+-f docker-compose.networks.yml \
+config > docker-stack.yml
+
+docker-auto-labels docker-stack.yml
+
+docker stack deploy -c docker-stack.yml --with-registry-auth ${STACK_NAME}


### PR DESCRIPTION
L’objectif est de tagguer les images docker avec le numéro de version (en plus de nos tags `qa` et `prod`)

Le process de build/push/deploy a été revu pour utiliser les variables correctement suivant l'étape.
3 scripts ont été ajoutés pour rationnaliser le tout, et ils sont utilisés par `make push-dev/qa/prod` et `make deploy-dev/qa/prod`